### PR TITLE
Fix openssl 1.0.2 vs 1.1.0 incompatibility

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -34,7 +34,7 @@ curl -s $TARBALL_URL | tar xz -C $output_dir
 
 echo "Downloading additional dependencies" | indent
 curl -s https://s3.amazonaws.com/proscia-viewer/additional_deps.tar.gz.enc -O
-openssl enc -d -aes-256-cbc -in additional_deps.tar.gz.enc -out additional_deps.tar.gz -kfile $ENVFILE/DEPENDENCIES_KEY
+openssl enc -d -aes-256-cbc -in additional_deps.tar.gz.enc -out additional_deps.tar.gz -pass file:$ENVFILE/DEPENDENCIES_KEY -md md5
 tar xzf additional_deps.tar.gz -C $output_dir
 
 if [ $? != 0 ]; then


### PR DESCRIPTION
The default for -md changed, so force to value had in 1.0.2
ref: https://github.com/fastlane/fastlane/issues/9542